### PR TITLE
Paul working

### DIFF
--- a/kafka-sample-programs/pom.xml
+++ b/kafka-sample-programs/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11</version>
+            <version>2.9.9</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Jackson dependency in kafka examples has security warning - changed from 2.8.x to 2.9.9 in pom.xml.